### PR TITLE
Fix: Hide button text in ChatBox on narrow mobile views

### DIFF
--- a/src/components/ChatBox.tsx
+++ b/src/components/ChatBox.tsx
@@ -68,7 +68,7 @@ const AnimatedButtonText: React.FC<{ text: string; isActive: boolean }> = ({ tex
   }, [isActive, characters.length]);
 
   return (
-    <span className="relative inline-block ml-2 text-sm hidden sm:inline" style={{ color: 'var(--foreground)' }}>
+    <span className="relative ml-2 text-sm hidden sm:inline-block" style={{ color: 'var(--foreground)' }}>
       {/* Invisible placeholder keeps width constant */}
       <span className="opacity-0 select-none pointer-events-none">{text}</span>
 


### PR DESCRIPTION
Adjusted Tailwind CSS classes for the 'Search', 'Instant', and 'Agent' button text labels within the ChatBox component.

The text was reportedly not hiding on narrow mobile views as intended. Changed the className on the AnimatedButtonText component's span from 'relative inline-block ml-2 text-sm hidden sm:inline' to 'relative ml-2 text-sm hidden sm:inline-block'.

This ensures that 'display: none' (from 'hidden') is the default state, and 'display: inline-block' is applied at the 'sm' breakpoint (640px) and wider, providing a more robust hiding mechanism on small screens.